### PR TITLE
Improve temporary directory handling

### DIFF
--- a/hyde
+++ b/hyde
@@ -32,8 +32,11 @@ return match ((function () {
         // As the Phar archive is readonly, we define a temporary directory
         // that Laravel can use to store the compiled views, cache files,
         // and config files, all to allow the binary to run anywhere,
-        // Todo: Include the application version in the hash string to force regeneration when updating the binary
-        define('HYDE_TEMP_DIR', sprintf('%s/hyde/%s', sys_get_temp_dir(), md5(HYDE_WORKING_DIR)));
+        define('HYDE_TEMP_DIR', sprintf('%s/hyde/%s',
+            // Todo: Include the application version in the hash string
+            //       to force regeneration when updating the binary.
+            sys_get_temp_dir(), md5(HYDE_WORKING_DIR)
+        ));
 
         // Create and set up the temporary directory if it doesn't exist
         if (! is_dir(HYDE_TEMP_DIR)) {


### PR DESCRIPTION
## Changes

### Change temporary directory format to use subdirectories

This means that instead of prefixing a bunch of directories, we put them all under a dedicated parent directory. This makes it easier to clear the temporary files.

### Todo: Include the application version in the hash string

This will force regeneration when updating the binary, preventing issues with differing caches.