### PR TITLE
Improve internal build command

### DIFF
--- a/app/Commands/Internal/BuildApplicationBinaryCommand.php
+++ b/app/Commands/Internal/BuildApplicationBinaryCommand.php
@@ -61,6 +61,8 @@ class BuildApplicationBinaryCommand extends Command
     {
         unlink(__DIR__.'/../../../config/app.php');
         rename(__DIR__.'/../../../box.json.bak', __DIR__.'/../../../box.json');
+
+        $this->clearCachedConfiguration(true);
     }
 
     protected function clearCachedConfiguration(bool $silent = false): void

--- a/app/Commands/Internal/BuildApplicationBinaryCommand.php
+++ b/app/Commands/Internal/BuildApplicationBinaryCommand.php
@@ -63,7 +63,7 @@ class BuildApplicationBinaryCommand extends Command
         rename(__DIR__.'/../../../box.json.bak', __DIR__.'/../../../box.json');
     }
 
-    protected function clearCachedConfiguration(): void
+    protected function clearCachedConfiguration(bool $silent = false): void
     {
         $configPath = $this->laravel->getCachedConfigPath();
 
@@ -71,7 +71,9 @@ class BuildApplicationBinaryCommand extends Command
             File::delete($configPath);
         }
 
-        $this->components->info('Configuration cache cleared successfully.');
+        if (! $silent) {  
+            $this->components->info('Configuration cache cleared successfully.');
+        }
     }
 
     protected function cacheConfiguration(): void


### PR DESCRIPTION
Clears the cached configuration when resetting build environment, preventing cache issues when running from source. The cache is only temporarily needed when building the Phar.