### PR TITLE
Add app version constant to Application class

### DIFF
--- a/app/Application.php
+++ b/app/Application.php
@@ -6,6 +6,8 @@ namespace App;
 
 class Application extends \Hyde\Foundation\Application
 {
+    final public const APP_VERSION = '0.1.0';
+
     public function getCachedPackagesPath(): string
     {
         // Since we have a custom path for the cache directory, we need to return it here.

--- a/tests/Unit/ApplicationTest.php
+++ b/tests/Unit/ApplicationTest.php
@@ -3,6 +3,12 @@
 use App\Application;
 use Hyde\Foundation\Application as HydeApplication;
 
+test('application version constant follows semantic versioning', function () {
+    $version = Application::APP_VERSION;
+
+    expect($version)->toMatch('/^\d+\.\d+\.\d+$/');
+});
+
 test('custom application extends Hyde application', function () {
     expect(new Application())->toBeInstanceOf(HydeApplication::class);
 });


### PR DESCRIPTION
## Abstract

This allows us to keep track of the version of the HydeCLI application within the codebase.

### Alternative implementations

I was not sure if this was the best option, or if we should add a dedicated interface. Below is the ChatGPT discussion.

---

The decision between adding a new `APP_VERSION` constant to your Laravel Application child class or creating an empty `App` interface with a `VERSION` constant depends on the design principles you want to follow and the purpose of the version information.

Here are some considerations for each option:

1. **Adding `APP_VERSION` to Laravel Application Child Class:**

   - **Pros:**
     - Directly ties the version information to the application class, making it easy to access.
     - Laravel's Application class is a logical place for configuration and application-level constants.

   - **Cons:**
     - It may not be the most semantically clean approach if the version is not tightly related to the application instance.

   - **Example:**
     ```php
     class MyApplication extends Illuminate\Foundation\Application
     {
         const APP_VERSION = '1.0.0';
     }
     ```

2. **Creating `App` Interface with `VERSION` Constant:**

   - **Pros:**
     - Allows for a more abstract and decoupled approach, especially if version information is not strictly tied to the application class.
     - Better supports the principle of dependency inversion and separation of concerns.

   - **Cons:**
     - Adds an interface that might seem unnecessary if the version information is tightly related to the application.

   - **Example:**
     ```php
     interface App
     {
         const VERSION = '1.0.0';
     }

     class MyApplication extends Illuminate\Foundation\Application implements App
     {
         // Implementation...
     }
     ```

Consider the following questions to guide your decision:

- **Is the version information strictly related to the application class?**
  - If yes, adding it directly to the application class may be more straightforward.

- **Do you anticipate the need for different implementations of the application (e.g., for testing or different environments)?**
  - If yes, an interface might be beneficial, allowing for different implementations to share a common version contract.

- **Do you want to follow SOLID principles and encourage a more abstract design?**
  - If yes, an interface might be a more appropriate choice.

In conclusion, both options are valid, and the best choice depends on the specific requirements and design goals of your Laravel application.