### PR TITLE
Update Codecov configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,8 +38,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
 
   run-tests:
     needs: coverage-tests


### PR DESCRIPTION
Since we installed the app, we don't need the token. Disabling this enabled Codecov again.