### PR TITLE
Exclude bin directory from distributed package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 
 .github/ export-ignore
 tests/ export-ignore
+bin/ export-ignore
 CHANGELOG.md export-ignore
 LICENSE.md export-ignore
 SECURITY.md export-ignore


### PR DESCRIPTION
We don't need these internal scrips to be distributed