### PR TITLE
Update release publisher to commit binary 

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -70,6 +70,12 @@ jobs:
           sha256sum hyde > checksum.txt
           echo "SHA256 checksum of the application binary: $(cat checksum.txt)"
 
+      - name: Commit executable
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: builds/hyde
+          message: "Build standalone executable"
+
       - name: Upload executable
         uses: actions/upload-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,4 @@
 /vendor
-/node_modules
-/builds
 /.idea
-/.vscode
-/.vagrant
-/.cache
-.phpunit.result.cache
-
+builds
 .env
-
-# /_site

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /vendor
 /.idea
-builds
 .env


### PR DESCRIPTION
Seems to be required in order to distribute through Packagist, see https://github.com/laravel-zero/laravel-zero/issues/476.