### PR TITLE
Build application in release creator workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -36,19 +36,46 @@ jobs:
           git fetch origin master:master
           git reset --hard master
 
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --no-suggest --prefer-dist
+
       - name: Bump application version
-        id: bump-version
+        id: build-version
         run: |
           php ./bin/bump-application-version.php ${{ github.event.inputs.type }}
           echo "version=$(php ./bin/get-release-version.php)" >> $GITHUB_OUTPUT
           echo "Version: v$(php ./bin/get-release-version.php)"
 
+      - name: Build executable
+        run: php hyde standalone:build --build-version-suffix="${{ steps.build-version.outputs.sha_short }}"
+
+      - name: Verify executable
+        run: php builds/hyde
+
+      - name: Verify executable version
+        run: php builds/hyde --version
+
+      - name: Upload executable artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: hyde
+          path: builds/hyde
+
       - name: Create pull request
         uses: peter-evans/create-pull-request@v5
         with:
-          commit-message: "HydeCLI v${{ steps.bump-version.outputs.version }}"
-          title: "HydeCLI v${{ steps.bump-version.outputs.version }}"
-          branch: "release/v${{ steps.bump-version.outputs.version }}"
+          commit-message: "HydeCLI v${{ steps.build-version.outputs.version }}"
+          title: "HydeCLI v${{ steps.build-version.outputs.version }}"
+          branch: "release/v${{ steps.build-version.outputs.version }}"
           delete-branch: true
 
           body: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -70,12 +70,6 @@ jobs:
           sha256sum hyde > checksum.txt
           echo "SHA256 checksum of the application binary: $(cat checksum.txt)"
 
-      - name: Commit executable
-        uses: EndBug/add-and-commit@v9
-        with:
-          add: builds/hyde
-          message: "Build standalone executable"
-
       - name: Upload executable
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,67 +29,7 @@ jobs:
           git merge stable
           git push origin master
 
-  build:
-    runs-on: ubuntu-latest
-    name: Build standalone executable
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v3
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
-
-      - name: Install dependencies
-        run: composer install --no-interaction --no-progress --no-suggest --prefer-dist
-
-      - name: Get build version
-        id: build-version
-        run: |
-          echo "version=$(php ./bin/get-release-version.php)" >> $GITHUB_OUTPUT
-          echo "Version: v$(php ./bin/get-release-version.php)"
-          php ./bin/get-release-version.php > version
-
-      - name: Build executable
-        run: php hyde standalone:build --build-version-suffix="${{ steps.build-version.outputs.sha_short }}"
-
-      - name: Verify executable
-        run: php builds/hyde
-
-      - name: Verify executable version
-        run: php builds/hyde --version
-
-      - name: Calculate checksum
-        run: |
-          cd builds
-          sha256sum hyde > checksum.txt
-          echo "SHA256 checksum of the application binary: $(cat checksum.txt)"
-
-      - name: Upload executable
-        uses: actions/upload-artifact@v3
-        with:
-          name: hyde
-          path: builds/hyde
-
-      - name: Upload the checksum artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: checksum
-          path: builds/checksum.txt
-
-      - name: Upload the version number artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: version
-          path: version
-
   release:
-    needs: build
     runs-on: ubuntu-latest
     name: Publish release
 
@@ -97,6 +37,11 @@ jobs:
       contents: write
 
     steps:
+      - uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ref: stable
+
       - name: Download the application artifact
         uses: actions/download-artifact@v3
         with:
@@ -116,13 +61,11 @@ jobs:
 
       - name: Prepare version information
         run:  |
-          echo "CHECKSUM=$(cat builds/checksum.txt | cut -d ' ' -f 1)" >> $GITHUB_ENV
-          echo "VERSION=$(cat version)" >> $GITHUB_ENV
+          echo "VERSION=$(php ./bin/get-release-version.php)" >> $GITHUB_ENV
 
       - name: Print version information
         run: |
           echo "Version: v${{ env.VERSION }}"
-          echo "Checksum: ${{ env.CHECKSUM }}"
 
       - name: Create a release
         uses: ncipollo/release-action@v1
@@ -132,4 +75,4 @@ jobs:
           commit: ${{ github.sha }}
           updateOnlyUnreleased: true
           generateReleaseNotes: true
-          artifacts: builds/hyde, builds/checksum.txt
+          artifacts: builds/hyde

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,7 +9,7 @@ on:
     branches: [ "stable" ]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
 


### PR DESCRIPTION
Since stable is a protected branch, we can't commit there, which we need to do in order to publish to Packagist, see https://github.com/hydephp/cli/pull/37

It also removes the checksum code to keep things simple, and because we currently just print it as we recently removed it from the body to keep things simple.
