### PR TITLE
Add files not needed for Composer installation to export ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,4 +22,4 @@ box.json export-ignore
 phpunit.xml export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
-hyde export-ignore
+/hyde export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,8 +7,17 @@
 *.php diff=php
 
 .github/ export-ignore
+config/ export-ignore
 tests/ export-ignore
+app/ export-ignore
 bin/ export-ignore
+
 CHANGELOG.md export-ignore
 LICENSE.md export-ignore
 SECURITY.md export-ignore
+composer.lock export-ignore
+box.json export-ignore
+phpunit.xml export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+hyde export-ignore


### PR DESCRIPTION
We don't need these when installing the standalone globally through Composer. We just want the build, the composer.json and the license file.

Based on the [Pint configuration](https://github.com/laravel/pint/blob/main/.gitattributes).

Before:
```
├── README.md
├── app
│   ├── Application.php
│   ├── Commands
│   │   ├── Internal
│   │   │   ├── BuildApplicationBinaryCommand.php
│   │   │   └── Describer.php
│   │   ├── NewProjectCommand.php
│   │   ├── ServeCommand.php
│   │   └── VendorPublishCommand.php
│   ├── Providers
│   │   └── AppServiceProvider.php
│   ├── bootstrap.php
│   ├── config.php
│   └── storage
│       ├── app
│       └── framework
│           ├── cache
│           │   └── data
│           └── views
├── box.json
├── builds
│   └── hyde
├── composer.json
├── composer.lock
├── config
├── hyde
└── phpunit.xml

12 directories, 16 files
```

After:
```
├── README.md
├── builds
│   └── hyde
└── composer.json

1 directory, 3 files
```