### PR TITLE
Remove development dependencies when building release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -36,14 +36,10 @@ jobs:
           git fetch origin master:master
           git reset --hard master
 
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v3
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
+      - name: Remove development dependencies
+        run: |
+          composer remove mockery/mockery --dev --no-install
+          composer remove pestphp/pest --dev --no-install
 
       - name: Install dependencies
         run: composer install --no-interaction --no-progress --no-suggest --prefer-dist


### PR DESCRIPTION
Due to the way that distributions for Packagist needs to be configured, according to the [Laravel Zero docs](https://laravel-zero.com/docs/build-a-standalone-application#distribute-via-packagist), all dependencies need to be dev-dependencies.

This presents a problem. We don't want to include the actual development dependencies in the release. My best solution as of now is to simply remove them before building the release version. Sadly, this means we cannot cache the Composer packages for the job anymore.

Fixes https://github.com/hydephp/cli/issues/26. Tested in https://github.com/caendesilva/hyde-standalone-release-experiments/actions/runs/7172386137/job/19529422427.