### PR TITLE
Remove realtime compiler server proxy caching

### DIFF
--- a/app/Commands/ServeCommand.php
+++ b/app/Commands/ServeCommand.php
@@ -29,10 +29,6 @@ class ServeCommand extends BaseServeCommand
     {
         $path = HYDE_TEMP_DIR.'/bin/server.php';
 
-        if (File::exists($path)) {
-            return $path;
-        }
-
         $this->createServer($path);
 
         return $path;

--- a/tests/Unit/ServeCommandTest.php
+++ b/tests/Unit/ServeCommandTest.php
@@ -11,7 +11,7 @@ const HYDE_TEMP_DIR = '/path/to/temp/dir';
 
 test('getExecutablePath method proxies server executable', function () {
     HydeKernel::setInstance(new HydeKernel(HYDE_WORKING_DIR));
-    File::shouldReceive('exists')->twice()->andReturnFalse();
+    File::shouldReceive('exists')->once()->andReturnFalse();
     File::shouldReceive('ensureDirectoryExists')->once()->with('/path/to/temp/dir/bin');
     File::shouldReceive('put')->once()->withArgs(function ($path, $contents) {
         expect($path)->toBe('/path/to/temp/dir/bin/server.php')


### PR DESCRIPTION
This causes issues when using different Hyde binaries in different locations. Just wasted half an hour finding out that the reason my code didn't change was because the server proxy was generated with the global version and thus used that archive's code, instead of the development build in my parent directory.

This change makes to that the proxy is regenerated each time the server starts, which should not have any real performance impact, especially since it is just when the serve command is run.