### PR TITLE
Add experimental command early exit

### DIFF
--- a/app/Commands/SelfUpdateCommand.php
+++ b/app/Commands/SelfUpdateCommand.php
@@ -102,6 +102,9 @@ class SelfUpdateCommand extends Command
             // Verify the application version
             passthru('hyde --version');
 
+            // Experimental early exit
+            exit(0);
+
             return Command::SUCCESS;
         } catch (Throwable $exception) {
             $this->output->error('Something went wrong while updating the application!');


### PR DESCRIPTION
May fix `PHP Fatal error: Uncaught ErrorException: include(): zlib: data error in phar:///usr/local/bin/hyde/.box/vendor/composer/ClassLoader.php:576` see https://github.com/hydephp/cli/issues/60#issuecomment-2061673762

Due to the nature of the system I can't verify if it works or not until after the release...