### PR TITLE
Harden GitHub Action workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Import GPG key
         if: github.event.repository.full_name == 'hydephp/cli'
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4
         with:
           gpg_private_key: ${{ secrets.GPG_SIGNING_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_SIGNING_KEY_PASSPHRASE }}
@@ -101,7 +101,7 @@ jobs:
         run: git restore composer.json composer.lock
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@9153d834b60caba6d51c9b9510b087acf9f33f83
         with:
           commit-message: "HydeCLI v${{ steps.build-version.outputs.version }}"
           title: "HydeCLI v${{ steps.build-version.outputs.version }}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -51,7 +51,7 @@ jobs:
           echo "Version: v${{ env.VERSION }}"
 
       - name: Create a release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5
         with:
           name: v${{ env.VERSION }}
           tag: v${{ env.VERSION }}


### PR DESCRIPTION
Pins third party workflows to specific commits and sets up Dependabot to handle dependency updates.