### PR TITLE
Attest build provenance

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,6 +19,7 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+  attestations: write
 
 jobs:
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,6 +18,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -111,6 +111,11 @@ jobs:
           name: signature
           path: builds/hyde.sig, builds/signature.bin
 
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: builds/hyde
+
       - name: Reset Composer file changes
         run: git restore composer.json composer.lock
 


### PR DESCRIPTION
Updates the release builder to attest the build provenance of the compiled standalone executable.

Resolves https://github.com/hydephp/cli/issues/176. Uses https://github.com/actions/attest-build-provenance