### PR TITLE
Add initial Docker support

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,82 @@
+name: Build Docker Image
+
+on:
+  push:
+    branches: [ "stable" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+
+  build-docker-image:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Install the cosign tool
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
+        with:
+          cosign-release: 'v2.2.4'
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Sign the resulting Docker image digests.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM php:8.2-cli-alpine
+
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
+RUN install-php-extensions zlib
+
+COPY hyde.phar /hyde.phar
+
+ENTRYPOINT ["/hyde.phar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM php:8.2-cli-alpine
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
 RUN install-php-extensions zlib
 
-COPY hyde.phar /hyde.phar
+COPY builds/hyde /hyde.phar
 
 ENTRYPOINT ["/hyde.phar"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,24 @@ curl -L https://github.com/hydephp/cli/releases/latest/download/hyde -o hyde
 chmod +x hyde && sudo mv hyde /usr/local/bin/hyde
 ```
 
+### Docker (Highly Experimental)
+
+> [!WARNING]
+> The HydePHP CLI Docker image is under development and is highly experimental. Proceed with caution and report the bugs you will certainly encounter.
+
+```bash
+docker pull ghcr.io/hydephp/cli:latest
+docker run --rm -it ghcr.io/hydephp/cli:latest <command>
+```
+
+Using the Docker image allows you to run the HydePHP CLI without installing any other dependencies like PHP or Composer on your local machine.
+
+If you want to use the HydePHP CLI Docker image as a global command, you can create a shell alias:
+
+```bash
+alias hyde='docker run --rm -it -v $(pwd):/app ghcr.io/hydephp/cli:latest'
+```
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
Begins with the setup of a Docker image to be used in the GitHub Container Registry. Images will be built and pushed from the stable branch, alongside the releases.

Using the Docker image allows you to run the HydePHP CLI without installing any other dependencies like PHP or Composer on your local machine.
