### PR TITLE
Tag Docker images with latest alongside stable

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,6 +52,9 @@ jobs:
         uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,ref=refs/heads/stable
+            type=raw,value=latest
 
       # Build and push Docker image with Buildx
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
### Abstract
- The `Extract Docker metadata` step now includes both `stable` and `latest` tags.
  ```yaml
  with:
    images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
    tags: |
      type=ref,ref=refs/heads/stable
      type=raw,value=latest
  ```
  This ensures that when you push to the `stable` branch, your Docker image is tagged with both `stable` and `latest`. This way, both `docker pull ghcr.io/hydephp/cli:stable` and `docker pull ghcr.io/hydephp/cli:latest` will fetch the same image.