### PR TITLE
Disable Docker build provenance in an attempt to fix GHCR adding ghost images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,6 +73,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false
 
       # Sign the resulting Docker image digests.
       # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
GitHub is adding corrupted near-empty `ghcr.io/hydephp/cli:sha256-*.sig` "ghost" images, hopefully disabling provenance could fix this. See https://github.com/docker/build-push-action/issues/771

![image](https://github.com/hydephp/cli/assets/95144705/a1ec011e-143f-4a23-86c4-446e24d2a92e)

Example output of trying to pull one of these

```
docker pull ghcr.io/hydephp/cli:sha256-23a782711e7cfdbaf0a5d13bd95d814ec614178cdbb9052750ace5d766ff59aa.sig
sha256-23a782711e7cfdbaf0a5d13bd95d814ec614178cdbb9052750ace5d766ff59aa.sig: Pulling from hydephp/cli
4c7c2b079c7b: Extracting [==================================================>]     235B/235B
failed to register layer: Error processing tar file(exit status 1): unexpected EOF
```