### PR TITLE
Revert "Disable Docker build provenance in an attempt to fix GHCR adding ghost images"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,7 +73,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          provenance: false
 
       # Sign the resulting Docker image digests.
       # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
Reverts hydephp/cli#220 as it did not fix https://github.com/hydephp/cli/issues/227