### PR TITLE
Revert "Bump sigstore/cosign-installer from 3.8.1 to 3.8.2"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
       # Install the cosign tool
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
-        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb #v3.8.2
+        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a #v3.8.1
         with:
           cosign-release: 'v2.2.4'
 


### PR DESCRIPTION
Reverts hydephp/cli#300 to see if it has anything to do with this test fail:
<img width="981" alt="image" src="https://github.com/user-attachments/assets/435159c5-0c25-4471-964a-c29b2710c0d8" />
