### PR TITLE
Fix parse_version() to accept SemVer prerelease/build suffixes

### DIFF
--- a/bin/build-manual.php
+++ b/bin/build-manual.php
@@ -4,6 +4,7 @@
 
 require_once __DIR__.'/../vendor/autoload.php';
 require_once __DIR__.'/lib/ansi-themes.php';
+require_once __DIR__.'/lib/manual-version.php';
 
 chdir(__DIR__.'/..');
 
@@ -358,16 +359,3 @@ function view(string $template, array $data): string
     return $template;
 }
 
-function parse_version(string $version): string
-{
-    preg_match('/HydePHP v(\d+\.\d+\.\d+) - \(HydePHP v(\d+\.\d+\.\d+)\)/', $version, $matches);
-
-    $cliVersion = $matches[1];
-    $hydeVersion = $matches[2];
-
-    if (! $matches || ! $cliVersion || ! $hydeVersion) {
-        throw new Exception("Failed to parse version: $version");
-    }
-
-    return "v$hydeVersion (CLI v$cliVersion)";
-}

--- a/bin/lib/manual-version.php
+++ b/bin/lib/manual-version.php
@@ -1,0 +1,15 @@
+<?php
+
+/** @internal Parses the `hyde --version` output used by the manual build. */
+function parse_version(string $version): string
+{
+    $semver = '\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?';
+
+    if (! preg_match("/HydePHP v($semver) - \(HydePHP v($semver)\)/", $version, $matches)) {
+        throw new Exception("Failed to parse version: $version");
+    }
+
+    [, $cliVersion, $hydeVersion] = $matches;
+
+    return "v$hydeVersion (CLI v$cliVersion)";
+}

--- a/tests/Unit/ManualVersionParserTest.php
+++ b/tests/Unit/ManualVersionParserTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__.'/../../bin/lib/manual-version.php';
+
+it('parses plain semver versions', function () {
+    expect(parse_version('HydePHP v3.0.0 - (HydePHP v3.0.0)'))
+        ->toBe('v3.0.0 (CLI v3.0.0)');
+});
+
+it('parses a dev framework version alongside a plain CLI version', function () {
+    expect(parse_version('HydePHP v3.0.0 - (HydePHP v3.0.0-dev)'))
+        ->toBe('v3.0.0-dev (CLI v3.0.0)');
+});
+
+it('parses dev prereleases on both versions', function () {
+    expect(parse_version('HydePHP v3.0.0-dev - (HydePHP v3.0.0-dev)'))
+        ->toBe('v3.0.0-dev (CLI v3.0.0-dev)');
+});
+
+it('parses arbitrary prerelease identifiers on both versions', function () {
+    expect(parse_version('HydePHP v3.0.0-beta.1 - (HydePHP v3.1.0-beta.2)'))
+        ->toBe('v3.1.0-beta.2 (CLI v3.0.0-beta.1)');
+});
+
+it('throws when the version string cannot be parsed', function () {
+    parse_version('not a version string');
+})->throws(Exception::class, 'Failed to parse version: not a version string');


### PR DESCRIPTION
## Summary
- Follow-on fix for a bug exposed by #335: since that PR now checks out the v3 development line before the docs build, `hyde --version` legitimately returns `HydePHP v3.0.0 - (HydePHP v3.0.0-dev)`, but `parse_version()` only accepted plain `x.y.z` on both versions and dereferenced `$matches[1]`/`[2]` before checking the regex actually matched, producing warnings followed by the intended exception.
- `parse_version()` now accepts standard SemVer prerelease (`-beta.1`) and build (`+build`) suffixes on **both** the CLI and framework versions, and checks the match result before reading capture groups.
- For this build, the manual now correctly renders `v3.0.0-dev (CLI v3.0.0)`.
- Moved the function to `bin/lib/manual-version.php` (matching the existing `bin/lib/ansi-themes.php` pattern) so it can be unit tested without executing the rest of `build-manual.php`'s side effects (mkdir, task registration).

## Test plan
- [x] `vendor/bin/pest tests/Unit/ManualVersionParserTest.php` — covers plain/dev/prerelease combinations on both versions plus the unparsable-input exception path
- [x] `php -l` on the changed files